### PR TITLE
changed how we clear buffer between commands and added a clear_buffer…

### DIFF
--- a/netlib/conn_type.py
+++ b/netlib/conn_type.py
@@ -54,7 +54,7 @@ class SSH(object):
         self.client_conn.sendall(command + "\n")
         not_done = True
         output = ""
-        self.clear_buffer()
+        #self.clear_buffer()
         while not_done:
             time.sleep(float(self.delay))
             if self.client_conn.recv_ready():
@@ -93,6 +93,9 @@ class Telnet(object):
 
     def close(self):
         return self.access.close()
+
+    def clear_buffer(self):
+        pass
 
     def set_enable(self, enable_password):
         import re


### PR DESCRIPTION
… method to telnet class to be consistent

Turns out that clearing your buffer can be a bad thing if you have a long running command - such as transferring images, via tftp, and need to query the output continually before moving to the next command.